### PR TITLE
Added HCL

### DIFF
--- a/email-domains.txt
+++ b/email-domains.txt
@@ -14,6 +14,7 @@
 @fortek.com
 @genpact.com
 @hanstaffing.com
+@hcl.com
 @hmgamerica.com
 @idctechnologies.com
 @iic.com


### PR DESCRIPTION
Adding HCL to the list. They are a known spammer and likely H-1B abuser ("likely" since they have a high percentage of H-1B applicants but not high enough to satisfy a hard level of confidence). Everything that I have ever received from them were typical body shop spam emails.